### PR TITLE
Add : signin 페이지 기능 구현 완료

### DIFF
--- a/src/pages/Signin/Signin.jsx
+++ b/src/pages/Signin/Signin.jsx
@@ -1,20 +1,81 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 import './Signin.scss';
 
 const Signin = () => {
+  const [email, setEmail] = useState();
+  const [password, setPassword] = useState();
+  const navigate = useNavigate();
+  const isAuthorized = localStorage.getItem('token') !== null;
+
+  useEffect(
+    () => (isAuthorized ? navigate('/todo') : navigate('/signin')),
+    [isAuthorized, navigate]
+  );
+
+  const handleEmailInput = e => {
+    setEmail(e.target.value);
+  };
+  const handlePasswordInput = e => {
+    setPassword(e.target.value);
+  };
+
+  const isEmailValid = email && email.includes('@');
+  const isPasswordValid = password && password.length >= 8;
+  const isAllVaild = isEmailValid && isPasswordValid;
+
+  const signin = (e, email, password) => {
+    e.preventDefault();
+    fetch('http://localhost:8000/auth/signin', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        email,
+        password,
+      }),
+    })
+      .then(res => res.json)
+      .then(data => {
+        if (data.access_token) {
+          localStorage.setItem('token', data.access_token);
+          navigate('/todo');
+        }
+      });
+    setEmail('');
+    setPassword('');
+  };
   return (
     <div className="signin">
       <h1>SignIn</h1>
-      <form className="signinForm">
+      <form className="signinForm" onSubmit={e => signin(e, email, password)}>
         <div className="inputBox">
           <label htmlFor="email">email</label>
-          <input id="email" type="text" data-testid="email-input" />
+          <input
+            id="email"
+            type="text"
+            value={email || ''}
+            onChange={handleEmailInput}
+            data-testid="email-input"
+          />
         </div>
         <div className="inputBox">
           <label htmlFor="password">password</label>
-          <input id="password" type="password" data-testid="password-input" />
+          <input
+            id="password"
+            type="password"
+            value={password || ''}
+            onChange={handlePasswordInput}
+            data-testid="password-input"
+          />
         </div>
-        <button data-testid="signin-button">submit</button>
+        <button
+          data-testid="signin-button"
+          disabled={isAllVaild ? false : true}
+        >
+          submit
+        </button>
       </form>
     </div>
   );


### PR DESCRIPTION
### Assignment 1 : 이메일, 비밀번호 유효성 검사기능 구현
- 조건
   - 이메일 조건: @ 포함 👉 includes() 메서드 사용
   - 비밀번호 조건: 8자 이상 👉 password의 length 활용
   - 유효성 검사에 따른 button disabled 속성 부여 👉 disabled 속성에 이메일과 비밀번호를 만족한다면 false, 만족하지 않는다면 true 설정

### Assignment 3 : 로그인 버튼 클릭 시, 로그인 진행 & 로그인이 정상적으로 완료되었을 시 /todo 경로로 이동
- localhost:8000/auth/signin 으로 post 요청 
- 완료시 localstorage.setItem() 사용하여 응답받은 JWT 저장 및 useNavigate()로 todo 이동

### Assignment 4 : 로그인 여부에 따른 리다이렉트 처리 구현
- 로컬 스토리지에 토큰이 있는 상태로 /signin 페이지에 접속한다면 /todo 경로로 리다이렉트 👉 useEffect()내에서 토큰 여부에 따라 navigate()로 /signin 또는 /todo로 이동